### PR TITLE
EXAMPLE: Don't use -rpath on windows

### DIFF
--- a/lib/config/discover.ml
+++ b/lib/config/discover.ml
@@ -1,0 +1,20 @@
+(*
+   This was taken from the dune manual at
+   https://dune.readthedocs.io/en/stable/quick-start.html
+*)
+module C = Configurator.V1
+
+let () =
+  C.main ~name:"configure-c-args" (fun c ->
+    let c_library_flags =
+      (* The -rpath option tells the linker to hardcode this search location in
+         the binary.
+         This works as long as libtree-sitter stays where it is, which is fine
+         for test executables. Production executables should instead link
+         statically against libtree-sitter to avoid problems in locating the
+         library at runtime. *)
+      match C.ocaml_config_var c "os_type" with
+      | Some "Win32" -> [] (* Compilation on Windows does not support rpath *)
+      | _ -> ["-Wl,-rpath,%{env:TREESITTER_LIBDIR=/usr/local/lib}"]
+    in
+    C.Flags.write_sexp "c_library_flags.sexp" c_library_flags)

--- a/lib/config/dune
+++ b/lib/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries dune.configurator))

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,5 @@
 ; required to install tree_sitter/parser.h
-(include_subdirs qualified)
+(data_only_dirs tree_sitter)
 
 (library
   (public_name tree-sitter-lang.typescript)
@@ -23,17 +23,14 @@
   ; The -rpath option tells the linker to hardcode this search location
   ; in the binary.
   ;
-  ; This works as long as libtree-sitter stays where it is, which is
-  ; fine for test executables. Production executables should instead
-  ; link statically against libree-sitter to avoid problems in locating
-  ; the library at runtime.
-  ;
+  ; Including the c_library_flags.sexp allows customizing the linker arguments
+  ; based on the platform we build on.
   (c_library_flags
     (
       -L%{env:TREESITTER_LIBDIR=/usr/local/lib}
       -lstdc++
       -ltree-sitter
-      -Wl,-rpath,%{env:TREESITTER_LIBDIR=/usr/local/lib}
+      (:include c_library_flags.sexp)
     )
   )
   (foreign_stubs
@@ -44,3 +41,7 @@
            -I .)
   )
 )
+
+(rule
+ (targets c_library_flags.sexp)
+ (action (run ./config/discover.exe)))


### PR DESCRIPTION
This is an exampling showing what needs to be done for the all the `semgrep-*` parsers as a correlate of https://github.com/semgrep/ocaml-tree-sitter-core/pull/86 .

Currently the build configuration hard-codes in the use of `-rpath`, but this is not a valid option on Windows. The change demonstrated here follows Dune's [recommended method](https://dune.readthedocs.io/en/stable/quick-start.html#defining-a-library-with-c-stubs-using-pkg-config) for dynamically computing c flags.

This change needs to be made in the code that generates the parser repositories, but I have not yet been able to figure out where that is located, so I'm presenting this demonstration for reference.

### Security

- [ ] Change has security implications (if so, ping the security team)
