### PR TITLE
Release: allow object destructuring patterns as semgrep patterns

### DIFF
--- a/fyi/tree-sitter-version
+++ b/fyi/tree-sitter-version
@@ -1,1 +1,1 @@
-tree-sitter 0.22.6 (fe20ef4a897aca50776903ada97bb1b04bbd7ef7)
+tree-sitter 0.22.6 (d521f0a0791d94f4442cf9be08322f6aabce20d6)

--- a/fyi/versions
+++ b/fyi/versions
@@ -52,8 +52,8 @@ Last change in file:
       Include common scanner.h in both custom scanners to avoid extra symbols
 ---
 File: semgrep-grammars/src/semgrep-typescript/typescript/grammar.js
-Git repo name: main
-Latest commit in repo: d68c1d87318808ec1b36ce89570ef6c0bc763f77
+Git repo name: ocaml-tree-sitter-semgrep
+Latest commit in repo: 3e89e370979ef9e9eaa783174d354b5475efcc5f
 Last change in file:
   commit f5c74b25c04be3b4901fe961e5c7a0489415aaaa
   Author: Nat Mote <nat@r2c.dev>

--- a/lib/Boilerplate.ml
+++ b/lib/Boilerplate.ml
@@ -1801,37 +1801,8 @@ and map_default_type (env : env) ((v1, v2) : CST.default_type) =
 
 and map_destructuring_pattern (env : env) (x : CST.destructuring_pattern) =
   (match x with
-  | `Obj_pat (v1, v2, v3) -> R.Case ("Obj_pat",
-      let v1 = (* "{" *) token env v1 in
-      let v2 =
-        (match v2 with
-        | Some (v1, v2) -> R.Option (Some (
-            let v1 =
-              (match v1 with
-              | Some x -> R.Option (Some (
-                  map_anon_choice_pair_pat_3ff9cbe env x
-                ))
-              | None -> R.Option None)
-            in
-            let v2 =
-              R.List (List.map (fun (v1, v2) ->
-                let v1 = (* "," *) token env v1 in
-                let v2 =
-                  (match v2 with
-                  | Some x -> R.Option (Some (
-                      map_anon_choice_pair_pat_3ff9cbe env x
-                    ))
-                  | None -> R.Option None)
-                in
-                R.Tuple [v1; v2]
-              ) v2)
-            in
-            R.Tuple [v1; v2]
-          ))
-        | None -> R.Option None)
-      in
-      let v3 = (* "}" *) token env v3 in
-      R.Tuple [v1; v2; v3]
+  | `Obj_pat x -> R.Case ("Obj_pat",
+      map_object_pattern env x
     )
   | `Array_pat (v1, v2, v3) -> R.Case ("Array_pat",
       let v1 = (* "[" *) token env v1 in
@@ -2962,6 +2933,38 @@ and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
               (match v2 with
               | Some x -> R.Option (Some (
                   map_anon_choice_pair_20c9acd env x
+                ))
+              | None -> R.Option None)
+            in
+            R.Tuple [v1; v2]
+          ) v2)
+        in
+        R.Tuple [v1; v2]
+      ))
+    | None -> R.Option None)
+  in
+  let v3 = (* "}" *) token env v3 in
+  R.Tuple [v1; v2; v3]
+
+and map_object_pattern (env : env) ((v1, v2, v3) : CST.object_pattern) =
+  let v1 = (* "{" *) token env v1 in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) -> R.Option (Some (
+        let v1 =
+          (match v1 with
+          | Some x -> R.Option (Some (
+              map_anon_choice_pair_pat_3ff9cbe env x
+            ))
+          | None -> R.Option None)
+        in
+        let v2 =
+          R.List (List.map (fun (v1, v2) ->
+            let v1 = (* "," *) token env v1 in
+            let v2 =
+              (match v2 with
+              | Some x -> R.Option (Some (
+                  map_anon_choice_pair_pat_3ff9cbe env x
                 ))
               | None -> R.Option None)
             in
@@ -4291,6 +4294,9 @@ let map_semgrep_pattern (env : env) (x : CST.semgrep_pattern) =
       let v5 = map_call_signature_ env v5 in
       let v6 = map_statement_block env v6 in
       R.Tuple [v1; v2; v3; v4; v5; v6]
+    )
+  | `Obj_pat x -> R.Case ("Obj_pat",
+      map_object_pattern env x
     )
   )
 

--- a/lib/CST.ml
+++ b/lib/CST.ml
@@ -768,16 +768,7 @@ and decorator_parenthesized_expression = (
 and default_type = (Token.t (* "=" *) * type_)
 
 and destructuring_pattern = [
-    `Obj_pat of (
-        Token.t (* "{" *)
-      * (
-            anon_choice_pair_pat_3ff9cbe option
-          * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option)
-              list (* zero or more *)
-        )
-          option
-      * Token.t (* "}" *)
-    )
+    `Obj_pat of object_pattern
   | `Array_pat of (
         Token.t (* "[" *)
       * (
@@ -1216,6 +1207,17 @@ and object_ = (
   * (
         anon_choice_pair_20c9acd option
       * (Token.t (* "," *) * anon_choice_pair_20c9acd option)
+          list (* zero or more *)
+    )
+      option
+  * Token.t (* "}" *)
+)
+
+and object_pattern = (
+    Token.t (* "{" *)
+  * (
+        anon_choice_pair_pat_3ff9cbe option
+      * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option)
           list (* zero or more *)
     )
       option
@@ -1733,6 +1735,7 @@ type semgrep_pattern = [
       * call_signature_
       * statement_block
     )
+  | `Obj_pat of object_pattern
 ]
 
 type anon_opt_choice_jsx_attr_name_rep_jsx_attr__8497dc0 =
@@ -2013,17 +2016,6 @@ type object_assignment_pattern (* inlined *) = (
     ]
   * Token.t (* "=" *)
   * expression
-)
-
-type object_pattern (* inlined *) = (
-    Token.t (* "{" *)
-  * (
-        anon_choice_pair_pat_3ff9cbe option
-      * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option)
-          list (* zero or more *)
-    )
-      option
-  * Token.t (* "}" *)
 )
 
 type optional_parameter (* inlined *) = (

--- a/lib/Parse.ml
+++ b/lib/Parse.ml
@@ -3523,6 +3523,7 @@ let children_regexps : (string * Run.exp option) list = [
       Token (Name "finally_clause");
       Token (Name "catch_clause");
       Token (Name "assign_lambda");
+      Token (Name "object_pattern");
     |];
   );
   "semgrep_expression",
@@ -12271,6 +12272,10 @@ let trans_semgrep_pattern ((kind, body) : mt) : CST.semgrep_pattern =
       | Alt (6, v) ->
           `Assign_lambda (
             trans_assign_lambda (Run.matcher_token v)
+          )
+      | Alt (7, v) ->
+          `Obj_pat (
+            trans_object_pattern (Run.matcher_token v)
           )
       | _ -> assert false
       )


### PR DESCRIPTION
## Summary
- Generated release from ocaml-tree-sitter-semgrep commit 3e89e37
- Upstream change: `fix(typescript): allow object destructuring patterns as semgrep patterns`

## Test plan
- [x] CI green