### PR TITLE
[typescript] regenerate parser for TS-specific Semgrep pattern positions

### DIFF
--- a/fyi/versions
+++ b/fyi/versions
@@ -52,8 +52,8 @@ Last change in file:
       Include common scanner.h in both custom scanners to avoid extra symbols
 ---
 File: semgrep-grammars/src/semgrep-typescript/typescript/grammar.js
-Git repo name: ocaml-tree-sitter-semgrep
-Latest commit in repo: 3e89e370979ef9e9eaa783174d354b5475efcc5f
+Git repo name: agent-a60623ae30bdc13c7
+Latest commit in repo: 8951d9e506814d549171220c36179d553da824cb
 Last change in file:
   commit f5c74b25c04be3b4901fe961e5c7a0489415aaaa
   Author: Nat Mote <nat@r2c.dev>

--- a/lib/Boilerplate.ml
+++ b/lib/Boilerplate.ml
@@ -823,7 +823,7 @@ and map_anon_choice_exp_9818c1b (env : env) (x : CST.anon_choice_exp_9818c1b) =
     )
   )
 
-and map_anon_choice_export_stmt_f90d83f (env : env) (x : CST.anon_choice_export_stmt_f90d83f) =
+and map_anon_choice_export_stmt_b35802f (env : env) (x : CST.anon_choice_export_stmt_b35802f) =
   (match x with
   | `Export_stmt x -> R.Case ("Export_stmt",
       map_export_statement env x
@@ -909,6 +909,9 @@ and map_anon_choice_export_stmt_f90d83f (env : env) (x : CST.anon_choice_export_
   | `Meth_sign x -> R.Case ("Meth_sign",
       map_method_signature env x
     )
+  | `Semg_ellips tok -> R.Case ("Semg_ellips",
+      (* "..." *) token env tok
+    )
   )
 
 and map_anon_choice_import_c99ceb4 (env : env) (x : CST.anon_choice_import_c99ceb4) =
@@ -984,7 +987,7 @@ and map_anon_choice_pat_3297d92 (env : env) (x : CST.anon_choice_pat_3297d92) =
     )
   )
 
-and map_anon_choice_prop_name_6cc9e4b (env : env) (x : CST.anon_choice_prop_name_6cc9e4b) =
+and map_anon_choice_prop_name_263cfab (env : env) (x : CST.anon_choice_prop_name_263cfab) =
   (match x with
   | `Prop_name x -> R.Case ("Prop_name",
       map_property_name env x
@@ -993,6 +996,9 @@ and map_anon_choice_prop_name_6cc9e4b (env : env) (x : CST.anon_choice_prop_name
       let v1 = map_property_name env v1 in
       let v2 = map_initializer_ env v2 in
       R.Tuple [v1; v2]
+    )
+  | `Semg_ellips tok -> R.Case ("Semg_ellips",
+      (* "..." *) token env tok
     )
   )
 
@@ -1038,6 +1044,38 @@ and map_anon_choice_type_id_a85f573 (env : env) (x : CST.anon_choice_type_id_a85
     )
   )
 
+and map_anon_choice_type_param_61809f5 (env : env) (x : CST.anon_choice_type_param_61809f5) =
+  (match x with
+  | `Type_param (v1, v2, v3, v4) -> R.Case ("Type_param",
+      let v1 =
+        (match v1 with
+        | Some tok -> R.Option (Some (
+            (* "const" *) token env tok
+          ))
+        | None -> R.Option None)
+      in
+      let v2 = (* identifier *) token env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> R.Option (Some (
+            map_constraint_ env x
+          ))
+        | None -> R.Option None)
+      in
+      let v4 =
+        (match v4 with
+        | Some x -> R.Option (Some (
+            map_default_type env x
+          ))
+        | None -> R.Option None)
+      in
+      R.Tuple [v1; v2; v3; v4]
+    )
+  | `Semg_ellips tok -> R.Case ("Semg_ellips",
+      (* "..." *) token env tok
+    )
+  )
+
 and map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp_208ebb4 (env : env) (opt : CST.anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp_208ebb4) =
   (match opt with
   | Some (v1, v2) -> R.Option (Some (
@@ -1079,6 +1117,12 @@ and map_array_ (env : env) ((v1, v2, v3) : CST.array_) =
   let v2 =
     map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp_208ebb4 env v2
   in
+  let v3 = (* "]" *) token env v3 in
+  R.Tuple [v1; v2; v3]
+
+and map_array_type (env : env) ((v1, v2, v3) : CST.array_type) =
+  let v1 = map_primary_type env v1 in
+  let v2 = (* "[" *) token env v2 in
   let v3 = (* "]" *) token env v3 in
   R.Tuple [v1; v2; v3]
 
@@ -1573,6 +1617,16 @@ and map_class_heritage (env : env) (x : CST.class_heritage) =
     )
   )
 
+and map_conditional_type (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.conditional_type) =
+  let v1 = map_type_ env v1 in
+  let v2 = (* "extends" *) token env v2 in
+  let v3 = map_type_ env v3 in
+  let v4 = (* "?" *) token env v4 in
+  let v5 = map_type_ env v5 in
+  let v6 = (* ":" *) token env v6 in
+  let v7 = map_type_ env v7 in
+  R.Tuple [v1; v2; v3; v4; v5; v6; v7]
+
 and map_constraint_ (env : env) ((v1, v2) : CST.constraint_) =
   let v1 =
     (match v1 with
@@ -1801,8 +1855,37 @@ and map_default_type (env : env) ((v1, v2) : CST.default_type) =
 
 and map_destructuring_pattern (env : env) (x : CST.destructuring_pattern) =
   (match x with
-  | `Obj_pat x -> R.Case ("Obj_pat",
-      map_object_pattern env x
+  | `Obj_pat (v1, v2, v3) -> R.Case ("Obj_pat",
+      let v1 = (* "{" *) token env v1 in
+      let v2 =
+        (match v2 with
+        | Some (v1, v2) -> R.Option (Some (
+            let v1 =
+              (match v1 with
+              | Some x -> R.Option (Some (
+                  map_anon_choice_pair_pat_3ff9cbe env x
+                ))
+              | None -> R.Option None)
+            in
+            let v2 =
+              R.List (List.map (fun (v1, v2) ->
+                let v1 = (* "," *) token env v1 in
+                let v2 =
+                  (match v2 with
+                  | Some x -> R.Option (Some (
+                      map_anon_choice_pair_pat_3ff9cbe env x
+                    ))
+                  | None -> R.Option None)
+                in
+                R.Tuple [v1; v2]
+              ) v2)
+            in
+            R.Tuple [v1; v2]
+          ))
+        | None -> R.Option None)
+      in
+      let v3 = (* "}" *) token env v3 in
+      R.Tuple [v1; v2; v3]
     )
   | `Array_pat (v1, v2, v3) -> R.Case ("Array_pat",
       let v1 = (* "[" *) token env v1 in
@@ -1862,11 +1945,11 @@ and map_enum_body (env : env) ((v1, v2, v3) : CST.enum_body) =
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) -> R.Option (Some (
-        let v1 = map_anon_choice_prop_name_6cc9e4b env v1 in
+        let v1 = map_anon_choice_prop_name_263cfab env v1 in
         let v2 =
           R.List (List.map (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
-            let v2 = map_anon_choice_prop_name_6cc9e4b env v2 in
+            let v2 = map_anon_choice_prop_name_263cfab env v2 in
             R.Tuple [v1; v2]
           ) v2)
         in
@@ -2217,6 +2300,11 @@ and map_extends_type_clause (env : env) ((v1, v2, v3) : CST.extends_type_clause)
 and map_finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
   let v1 = (* "finally" *) token env v1 in
   let v2 = map_statement_block env v2 in
+  R.Tuple [v1; v2]
+
+and map_flow_maybe_type (env : env) ((v1, v2) : CST.flow_maybe_type) =
+  let v1 = (* "?" *) token env v1 in
+  let v2 = map_primary_type env v2 in
   R.Tuple [v1; v2]
 
 and map_for_header (env : env) ((v1, v2, v3, v4, v5) : CST.for_header) =
@@ -2635,6 +2723,11 @@ and map_index_signature (env : env) ((v1, v2, v3, v4, v5) : CST.index_signature)
   in
   R.Tuple [v1; v2; v3; v4; v5]
 
+and map_index_type_query (env : env) ((v1, v2) : CST.index_type_query) =
+  let v1 = (* "keyof" *) token env v1 in
+  let v2 = map_primary_type env v2 in
+  R.Tuple [v1; v2]
+
 and map_infer_type (env : env) ((v1, v2, v3) : CST.infer_type) =
   let v1 = (* "infer" *) token env v1 in
   let v2 = (* identifier *) token env v2 in
@@ -2658,6 +2751,18 @@ and map_internal_module (env : env) ((v1, v2) : CST.internal_module) =
   let v1 = (* "namespace" *) token env v1 in
   let v2 = map_module__ env v2 in
   R.Tuple [v1; v2]
+
+and map_intersection_type (env : env) ((v1, v2, v3) : CST.intersection_type) =
+  let v1 =
+    (match v1 with
+    | Some x -> R.Option (Some (
+        map_type_ env x
+      ))
+    | None -> R.Option None)
+  in
+  let v2 = (* "&" *) token env v2 in
+  let v3 = map_type_ env v3 in
+  R.Tuple [v1; v2; v3]
 
 and map_labeled_statement (env : env) ((v1, v2, v3) : CST.labeled_statement) =
   let v1 = map_anon_choice_type_id_dd17e7d env v1 in
@@ -2703,6 +2808,13 @@ and map_lhs_expression (env : env) (x : CST.lhs_expression) =
       map_non_null_expression env x
     )
   )
+
+and map_lookup_type (env : env) ((v1, v2, v3, v4) : CST.lookup_type) =
+  let v1 = map_primary_type env v1 in
+  let v2 = (* "[" *) token env v2 in
+  let v3 = map_type_ env v3 in
+  let v4 = (* "]" *) token env v4 in
+  R.Tuple [v1; v2; v3; v4]
 
 and map_mapped_type_clause (env : env) ((v1, v2, v3, v4) : CST.mapped_type_clause) =
   let v1 = (* identifier *) token env v1 in
@@ -2946,38 +3058,6 @@ and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
   let v3 = (* "}" *) token env v3 in
   R.Tuple [v1; v2; v3]
 
-and map_object_pattern (env : env) ((v1, v2, v3) : CST.object_pattern) =
-  let v1 = (* "{" *) token env v1 in
-  let v2 =
-    (match v2 with
-    | Some (v1, v2) -> R.Option (Some (
-        let v1 =
-          (match v1 with
-          | Some x -> R.Option (Some (
-              map_anon_choice_pair_pat_3ff9cbe env x
-            ))
-          | None -> R.Option None)
-        in
-        let v2 =
-          R.List (List.map (fun (v1, v2) ->
-            let v1 = (* "," *) token env v1 in
-            let v2 =
-              (match v2 with
-              | Some x -> R.Option (Some (
-                  map_anon_choice_pair_pat_3ff9cbe env x
-                ))
-              | None -> R.Option None)
-            in
-            R.Tuple [v1; v2]
-          ) v2)
-        in
-        R.Tuple [v1; v2]
-      ))
-    | None -> R.Option None)
-  in
-  let v3 = (* "}" *) token env v3 in
-  R.Tuple [v1; v2; v3]
-
 and map_object_type (env : env) ((v1, v2, v3) : CST.object_type) =
   let v1 =
     (match v1 with
@@ -3006,11 +3086,11 @@ and map_object_type (env : env) ((v1, v2, v3) : CST.object_type) =
             ))
           | None -> R.Option None)
         in
-        let v2 = map_anon_choice_export_stmt_f90d83f env v2 in
+        let v2 = map_anon_choice_export_stmt_b35802f env v2 in
         let v3 =
           R.List (List.map (fun (v1, v2) ->
             let v1 = map_anon_choice_COMMA_5194cb4 env v1 in
-            let v2 = map_anon_choice_export_stmt_f90d83f env v2 in
+            let v2 = map_anon_choice_export_stmt_b35802f env v2 in
             R.Tuple [v1; v2]
           ) v3)
         in
@@ -3131,6 +3211,12 @@ and map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_e
   let v3 = (* ")" *) token env v3 in
   R.Tuple [v1; v2; v3]
 
+and map_parenthesized_type (env : env) ((v1, v2, v3) : CST.parenthesized_type) =
+  let v1 = (* "(" *) token env v1 in
+  let v2 = map_type_ env v2 in
+  let v3 = (* ")" *) token env v3 in
+  R.Tuple [v1; v2; v3]
+
 and map_pattern (env : env) (x : CST.pattern) =
   (match x with
   | `Choice_choice_choice_member_exp x -> R.Case ("Choice_choice_choice_member_exp",
@@ -3243,165 +3329,78 @@ and map_primary_expression (env : env) (x : CST.primary_expression) =
 
 and map_primary_type (env : env) (x : CST.primary_type) =
   (match x with
-  | `Paren_type (v1, v2, v3) -> R.Case ("Paren_type",
-      let v1 = (* "(" *) token env v1 in
-      let v2 = map_type_ env v2 in
-      let v3 = (* ")" *) token env v3 in
-      R.Tuple [v1; v2; v3]
-    )
-  | `Pred_type x -> R.Case ("Pred_type",
-      map_predefined_type env x
-    )
-  | `Id tok -> R.Case ("Id",
-      (* identifier *) token env tok
-    )
-  | `Nested_type_id x -> R.Case ("Nested_type_id",
-      map_nested_type_identifier env x
-    )
-  | `Gene_type x -> R.Case ("Gene_type",
-      map_generic_type env x
-    )
-  | `Obj_type x -> R.Case ("Obj_type",
-      map_object_type env x
-    )
-  | `Array_type (v1, v2, v3) -> R.Case ("Array_type",
-      let v1 = map_primary_type env v1 in
-      let v2 = (* "[" *) token env v2 in
-      let v3 = (* "]" *) token env v3 in
-      R.Tuple [v1; v2; v3]
-    )
-  | `Tuple_type (v1, v2, v3, v4) -> R.Case ("Tuple_type",
-      let v1 = (* "[" *) token env v1 in
-      let v2 =
-        (match v2 with
-        | Some (v1, v2) -> R.Option (Some (
-            let v1 = map_tuple_type_member env v1 in
-            let v2 =
-              R.List (List.map (fun (v1, v2) ->
-                let v1 = (* "," *) token env v1 in
-                let v2 = map_tuple_type_member env v2 in
-                R.Tuple [v1; v2]
-              ) v2)
-            in
-            R.Tuple [v1; v2]
-          ))
-        | None -> R.Option None)
-      in
-      let v3 =
-        (match v3 with
-        | Some tok -> R.Option (Some (
-            (* "," *) token env tok
-          ))
-        | None -> R.Option None)
-      in
-      let v4 = (* "]" *) token env v4 in
-      R.Tuple [v1; v2; v3; v4]
-    )
-  | `Flow_maybe_type (v1, v2) -> R.Case ("Flow_maybe_type",
-      let v1 = (* "?" *) token env v1 in
-      let v2 = map_primary_type env v2 in
-      R.Tuple [v1; v2]
-    )
-  | `Type_query (v1, v2) -> R.Case ("Type_query",
-      let v1 = (* "typeof" *) token env v1 in
-      let v2 =
-        (match v2 with
-        | `Type_query_subs_exp x -> R.Case ("Type_query_subs_exp",
-            map_type_query_subscript_expression env x
-          )
-        | `Type_query_member_exp x -> R.Case ("Type_query_member_exp",
-            map_type_query_member_expression env x
-          )
-        | `Type_query_call_exp x -> R.Case ("Type_query_call_exp",
-            map_type_query_call_expression env x
-          )
-        | `Type_query_inst_exp x -> R.Case ("Type_query_inst_exp",
-            map_type_query_instantiation_expression env x
-          )
-        | `Id tok -> R.Case ("Id",
-            (* identifier *) token env tok
-          )
-        | `This tok -> R.Case ("This",
-            (* "this" *) token env tok
-          )
+  | `Choice_paren_type x -> R.Case ("Choice_paren_type",
+      (match x with
+      | `Paren_type x -> R.Case ("Paren_type",
+          map_parenthesized_type env x
         )
-      in
-      R.Tuple [v1; v2]
+      | `Pred_type x -> R.Case ("Pred_type",
+          map_predefined_type env x
+        )
+      | `Id tok -> R.Case ("Id",
+          (* identifier *) token env tok
+        )
+      | `Nested_type_id x -> R.Case ("Nested_type_id",
+          map_nested_type_identifier env x
+        )
+      | `Gene_type x -> R.Case ("Gene_type",
+          map_generic_type env x
+        )
+      | `Obj_type x -> R.Case ("Obj_type",
+          map_object_type env x
+        )
+      | `Array_type x -> R.Case ("Array_type",
+          map_array_type env x
+        )
+      | `Tuple_type x -> R.Case ("Tuple_type",
+          map_tuple_type env x
+        )
+      | `Flow_maybe_type x -> R.Case ("Flow_maybe_type",
+          map_flow_maybe_type env x
+        )
+      | `Type_query x -> R.Case ("Type_query",
+          map_type_query env x
+        )
+      | `Index_type_query x -> R.Case ("Index_type_query",
+          map_index_type_query env x
+        )
+      | `This tok -> R.Case ("This",
+          (* "this" *) token env tok
+        )
+      | `Exis_type tok -> R.Case ("Exis_type",
+          (* "*" *) token env tok
+        )
+      | `Lit_type x -> R.Case ("Lit_type",
+          map_literal_type env x
+        )
+      | `Lookup_type x -> R.Case ("Lookup_type",
+          map_lookup_type env x
+        )
+      | `Cond_type x -> R.Case ("Cond_type",
+          map_conditional_type env x
+        )
+      | `Temp_lit_type x -> R.Case ("Temp_lit_type",
+          map_template_literal_type env x
+        )
+      | `Inte_type x -> R.Case ("Inte_type",
+          map_intersection_type env x
+        )
+      | `Union_type x -> R.Case ("Union_type",
+          map_union_type env x
+        )
+      | `Const tok -> R.Case ("Const",
+          (* "const" *) token env tok
+        )
+      )
     )
-  | `Index_type_query (v1, v2) -> R.Case ("Index_type_query",
-      let v1 = (* "keyof" *) token env v1 in
-      let v2 = map_primary_type env v2 in
-      R.Tuple [v1; v2]
+  | `Semg_ellips tok -> R.Case ("Semg_ellips",
+      (* "..." *) token env tok
     )
-  | `This tok -> R.Case ("This",
-      (* "this" *) token env tok
+  | `Semg_meta tok -> R.Case ("Semg_meta",
+      (* pattern \$[A-Z_][A-Z_0-9]* *) token env tok
     )
-  | `Exis_type tok -> R.Case ("Exis_type",
-      (* "*" *) token env tok
-    )
-  | `Lit_type x -> R.Case ("Lit_type",
-      map_literal_type env x
-    )
-  | `Lookup_type (v1, v2, v3, v4) -> R.Case ("Lookup_type",
-      let v1 = map_primary_type env v1 in
-      let v2 = (* "[" *) token env v2 in
-      let v3 = map_type_ env v3 in
-      let v4 = (* "]" *) token env v4 in
-      R.Tuple [v1; v2; v3; v4]
-    )
-  | `Cond_type (v1, v2, v3, v4, v5, v6, v7) -> R.Case ("Cond_type",
-      let v1 = map_type_ env v1 in
-      let v2 = (* "extends" *) token env v2 in
-      let v3 = map_type_ env v3 in
-      let v4 = (* "?" *) token env v4 in
-      let v5 = map_type_ env v5 in
-      let v6 = (* ":" *) token env v6 in
-      let v7 = map_type_ env v7 in
-      R.Tuple [v1; v2; v3; v4; v5; v6; v7]
-    )
-  | `Temp_lit_type (v1, v2, v3) -> R.Case ("Temp_lit_type",
-      let v1 = (* "`" *) token env v1 in
-      let v2 =
-        R.List (List.map (fun x ->
-          (match x with
-          | `Temp_chars tok -> R.Case ("Temp_chars",
-              (* template_chars *) token env tok
-            )
-          | `Temp_type x -> R.Case ("Temp_type",
-              map_template_type env x
-            )
-          )
-        ) v2)
-      in
-      let v3 = (* "`" *) token env v3 in
-      R.Tuple [v1; v2; v3]
-    )
-  | `Inte_type (v1, v2, v3) -> R.Case ("Inte_type",
-      let v1 =
-        (match v1 with
-        | Some x -> R.Option (Some (
-            map_type_ env x
-          ))
-        | None -> R.Option None)
-      in
-      let v2 = (* "&" *) token env v2 in
-      let v3 = map_type_ env v3 in
-      R.Tuple [v1; v2; v3]
-    )
-  | `Union_type (v1, v2, v3) -> R.Case ("Union_type",
-      let v1 =
-        (match v1 with
-        | Some x -> R.Option (Some (
-            map_type_ env x
-          ))
-        | None -> R.Option None)
-      in
-      let v2 = (* "|" *) token env v2 in
-      let v3 = map_type_ env v3 in
-      R.Tuple [v1; v2; v3]
-    )
-  | `Const tok -> R.Case ("Const",
-      (* "const" *) token env tok
+  | `Semg_meta_ellips tok -> R.Case ("Semg_meta_ellips",
+      (* pattern \$\.\.\.[A-Z_][A-Z_0-9]* *) token env tok
     )
   )
 
@@ -3735,6 +3734,23 @@ and map_switch_statement (env : env) ((v1, v2, v3) : CST.switch_statement) =
   let v3 = map_switch_body env v3 in
   R.Tuple [v1; v2; v3]
 
+and map_template_literal_type (env : env) ((v1, v2, v3) : CST.template_literal_type) =
+  let v1 = (* "`" *) token env v1 in
+  let v2 =
+    R.List (List.map (fun x ->
+      (match x with
+      | `Temp_chars tok -> R.Case ("Temp_chars",
+          (* template_chars *) token env tok
+        )
+      | `Temp_type x -> R.Case ("Temp_type",
+          map_template_type env x
+        )
+      )
+    ) v2)
+  in
+  let v3 = (* "`" *) token env v3 in
+  R.Tuple [v1; v2; v3]
+
 and map_template_string (env : env) ((v1, v2, v3) : CST.template_string) =
   let v1 = (* "`" *) token env v1 in
   let v2 =
@@ -3799,6 +3815,33 @@ and map_try_statement (env : env) ((v1, v2, v3, v4) : CST.try_statement) =
       ))
     | None -> R.Option None)
   in
+  R.Tuple [v1; v2; v3; v4]
+
+and map_tuple_type (env : env) ((v1, v2, v3, v4) : CST.tuple_type) =
+  let v1 = (* "[" *) token env v1 in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) -> R.Option (Some (
+        let v1 = map_tuple_type_member env v1 in
+        let v2 =
+          R.List (List.map (fun (v1, v2) ->
+            let v1 = (* "," *) token env v1 in
+            let v2 = map_tuple_type_member env v2 in
+            R.Tuple [v1; v2]
+          ) v2)
+        in
+        R.Tuple [v1; v2]
+      ))
+    | None -> R.Option None)
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> R.Option (Some (
+        (* "," *) token env tok
+      ))
+    | None -> R.Option None)
+  in
+  let v4 = (* "]" *) token env v4 in
   R.Tuple [v1; v2; v3; v4]
 
 and map_tuple_type_member (env : env) (x : CST.tuple_type_member) =
@@ -3930,38 +3973,13 @@ and map_type_arguments (env : env) ((v1, v2, v3, v4, v5) : CST.type_arguments) =
   let v5 = (* ">" *) token env v5 in
   R.Tuple [v1; v2; v3; v4; v5]
 
-and map_type_parameter (env : env) ((v1, v2, v3, v4) : CST.type_parameter) =
-  let v1 =
-    (match v1 with
-    | Some tok -> R.Option (Some (
-        (* "const" *) token env tok
-      ))
-    | None -> R.Option None)
-  in
-  let v2 = (* identifier *) token env v2 in
-  let v3 =
-    (match v3 with
-    | Some x -> R.Option (Some (
-        map_constraint_ env x
-      ))
-    | None -> R.Option None)
-  in
-  let v4 =
-    (match v4 with
-    | Some x -> R.Option (Some (
-        map_default_type env x
-      ))
-    | None -> R.Option None)
-  in
-  R.Tuple [v1; v2; v3; v4]
-
 and map_type_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.type_parameters) =
   let v1 = (* "<" *) token env v1 in
-  let v2 = map_type_parameter env v2 in
+  let v2 = map_anon_choice_type_param_61809f5 env v2 in
   let v3 =
     R.List (List.map (fun (v1, v2) ->
       let v1 = (* "," *) token env v1 in
-      let v2 = map_type_parameter env v2 in
+      let v2 = map_anon_choice_type_param_61809f5 env v2 in
       R.Tuple [v1; v2]
     ) v3)
   in
@@ -3996,6 +4014,32 @@ and map_type_predicate (env : env) ((v1, v2, v3) : CST.type_predicate) =
 and map_type_predicate_annotation (env : env) ((v1, v2) : CST.type_predicate_annotation) =
   let v1 = (* ":" *) token env v1 in
   let v2 = map_type_predicate env v2 in
+  R.Tuple [v1; v2]
+
+and map_type_query (env : env) ((v1, v2) : CST.type_query) =
+  let v1 = (* "typeof" *) token env v1 in
+  let v2 =
+    (match v2 with
+    | `Type_query_subs_exp x -> R.Case ("Type_query_subs_exp",
+        map_type_query_subscript_expression env x
+      )
+    | `Type_query_member_exp x -> R.Case ("Type_query_member_exp",
+        map_type_query_member_expression env x
+      )
+    | `Type_query_call_exp x -> R.Case ("Type_query_call_exp",
+        map_type_query_call_expression env x
+      )
+    | `Type_query_inst_exp x -> R.Case ("Type_query_inst_exp",
+        map_type_query_instantiation_expression env x
+      )
+    | `Id tok -> R.Case ("Id",
+        (* identifier *) token env tok
+      )
+    | `This tok -> R.Case ("This",
+        (* "this" *) token env tok
+      )
+    )
+  in
   R.Tuple [v1; v2]
 
 and map_type_query_call_expression (env : env) ((v1, v2) : CST.type_query_call_expression) =
@@ -4080,6 +4124,18 @@ and map_type_query_subscript_expression (env : env) ((v1, v2, v3, v4, v5) : CST.
   in
   let v5 = (* "]" *) token env v5 in
   R.Tuple [v1; v2; v3; v4; v5]
+
+and map_union_type (env : env) ((v1, v2, v3) : CST.union_type) =
+  let v1 =
+    (match v1 with
+    | Some x -> R.Option (Some (
+        map_type_ env x
+      ))
+    | None -> R.Option None)
+  in
+  let v2 = (* "|" *) token env v2 in
+  let v3 = map_type_ env v3 in
+  R.Tuple [v1; v2; v3]
 
 and map_update_expression (env : env) (x : CST.update_expression) =
   (match x with
@@ -4295,8 +4351,17 @@ let map_semgrep_pattern (env : env) (x : CST.semgrep_pattern) =
       let v6 = map_statement_block env v6 in
       R.Tuple [v1; v2; v3; v4; v5; v6]
     )
-  | `Obj_pat x -> R.Case ("Obj_pat",
-      map_object_pattern env x
+  | `Deco x -> R.Case ("Deco",
+      map_decorator env x
+    )
+  | `Stmt x -> R.Case ("Stmt",
+      map_statement env x
+    )
+  | `Type x -> R.Case ("Type",
+      map_type_ env x
+    )
+  | `Type_pred x -> R.Case ("Type_pred",
+      map_type_predicate env x
     )
   )
 

--- a/lib/CST.ml
+++ b/lib/CST.ml
@@ -398,7 +398,7 @@ and anon_choice_exp_9818c1b = [
   | `Spread_elem of spread_element
 ]
 
-and anon_choice_export_stmt_f90d83f = [
+and anon_choice_export_stmt_b35802f = [
     `Export_stmt of export_statement
   | `Prop_sign of (
         accessibility_modifier option
@@ -419,6 +419,7 @@ and anon_choice_export_stmt_f90d83f = [
     )
   | `Index_sign of index_signature
   | `Meth_sign of method_signature
+  | `Semg_ellips of Token.t (* "..." *)
 ]
 
 and anon_choice_import_c99ceb4 = [
@@ -454,9 +455,10 @@ and anon_choice_pat_3297d92 = [
   | `Assign_pat of (pattern * Token.t (* "=" *) * expression)
 ]
 
-and anon_choice_prop_name_6cc9e4b = [
+and anon_choice_prop_name_263cfab = [
     `Prop_name of property_name
   | `Enum_assign of (property_name * initializer_)
+  | `Semg_ellips of Token.t (* "..." *)
 ]
 
 and anon_choice_type_id_43e1312 = [
@@ -478,6 +480,16 @@ and anon_choice_type_id_a85f573 = [
   | `Gene_type of generic_type
 ]
 
+and anon_choice_type_param_61809f5 = [
+    `Type_param of (
+        Token.t (* "const" *) option
+      * identifier (*tok*)
+      * constraint_ option
+      * default_type option
+    )
+  | `Semg_ellips of Token.t (* "..." *)
+]
+
 and anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp_208ebb4 =
   (anon_choice_exp_9818c1b option * anon_rep_COMMA_opt_choice_exp_ca698a5)
     option
@@ -497,6 +509,8 @@ and array_ = (
   * anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp_208ebb4
   * Token.t (* "]" *)
 )
+
+and array_type = (primary_type * Token.t (* "[" *) * Token.t (* "]" *))
 
 and arrow_function = (
     Token.t (* "async" *) option
@@ -666,6 +680,11 @@ and class_heritage = [
   | `Imples_clause of implements_clause
 ]
 
+and conditional_type = (
+    type_ * Token.t (* "extends" *) * type_ * Token.t (* "?" *) * type_
+  * Token.t (* ":" *) * type_
+)
+
 and constraint_ = (
     [ `Extends of Token.t (* "extends" *) | `COLON of Token.t (* ":" *) ]
   * type_
@@ -768,7 +787,16 @@ and decorator_parenthesized_expression = (
 and default_type = (Token.t (* "=" *) * type_)
 
 and destructuring_pattern = [
-    `Obj_pat of object_pattern
+    `Obj_pat of (
+        Token.t (* "{" *)
+      * (
+            anon_choice_pair_pat_3ff9cbe option
+          * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option)
+              list (* zero or more *)
+        )
+          option
+      * Token.t (* "}" *)
+    )
   | `Array_pat of (
         Token.t (* "[" *)
       * (
@@ -794,8 +822,8 @@ and else_clause = (Token.t (* "else" *) * statement)
 and enum_body = (
     Token.t (* "{" *)
   * (
-        anon_choice_prop_name_6cc9e4b
-      * (Token.t (* "," *) * anon_choice_prop_name_6cc9e4b)
+        anon_choice_prop_name_263cfab
+      * (Token.t (* "," *) * anon_choice_prop_name_263cfab)
           list (* zero or more *)
       * Token.t (* "," *) option
     )
@@ -935,6 +963,8 @@ and extends_type_clause = (
 )
 
 and finally_clause = (Token.t (* "finally" *) * statement_block)
+
+and flow_maybe_type = (Token.t (* "?" *) * primary_type)
 
 and for_header = (
     Token.t (* "(" *)
@@ -1106,6 +1136,8 @@ and index_signature = (
     ]
 )
 
+and index_type_query = (Token.t (* "keyof" *) * primary_type)
+
 and infer_type = (
     Token.t (* "infer" *)
   * identifier (*tok*)
@@ -1115,6 +1147,8 @@ and infer_type = (
 and initializer_ = (Token.t (* "=" *) * expression)
 
 and internal_module = (Token.t (* "namespace" *) * module__)
+
+and intersection_type = (type_ option * Token.t (* "&" *) * type_)
 
 and labeled_statement = (
     anon_choice_type_id_dd17e7d * Token.t (* ":" *) * statement
@@ -1137,6 +1171,10 @@ and lhs_expression = [
     ]
   | `Non_null_exp of non_null_expression
 ]
+
+and lookup_type = (
+    primary_type * Token.t (* "[" *) * type_ * Token.t (* "]" *)
+)
 
 and mapped_type_clause = (
     identifier (*tok*)
@@ -1213,23 +1251,12 @@ and object_ = (
   * Token.t (* "}" *)
 )
 
-and object_pattern = (
-    Token.t (* "{" *)
-  * (
-        anon_choice_pair_pat_3ff9cbe option
-      * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option)
-          list (* zero or more *)
-    )
-      option
-  * Token.t (* "}" *)
-)
-
 and object_type = (
     [ `LCURL of Token.t (* "{" *) | `LCURLBAR of Token.t (* "{|" *) ]
   * (
         [ `COMMA of Token.t (* "," *) | `SEMI of Token.t (* ";" *) ] option
-      * anon_choice_export_stmt_f90d83f
-      * (anon_choice_COMMA_5194cb4 * anon_choice_export_stmt_f90d83f)
+      * anon_choice_export_stmt_b35802f
+      * (anon_choice_COMMA_5194cb4 * anon_choice_export_stmt_b35802f)
           list (* zero or more *)
       * anon_choice_COMMA_5194cb4 option
     )
@@ -1269,6 +1296,8 @@ and parenthesized_expression = (
     ]
   * Token.t (* ")" *)
 )
+
+and parenthesized_type = (Token.t (* "(" *) * type_ * Token.t (* ")" *))
 
 and pattern = [
     `Choice_choice_choice_member_exp of [
@@ -1314,58 +1343,31 @@ and primary_expression = [
 ]
 
 and primary_type = [
-    `Paren_type of (Token.t (* "(" *) * type_ * Token.t (* ")" *))
-  | `Pred_type of predefined_type
-  | `Id of identifier (*tok*)
-  | `Nested_type_id of nested_type_identifier
-  | `Gene_type of generic_type
-  | `Obj_type of object_type
-  | `Array_type of (primary_type * Token.t (* "[" *) * Token.t (* "]" *))
-  | `Tuple_type of (
-        Token.t (* "[" *)
-      * (
-            tuple_type_member
-          * (Token.t (* "," *) * tuple_type_member) list (* zero or more *)
-        )
-          option
-      * Token.t (* "," *) option
-      * Token.t (* "]" *)
-    )
-  | `Flow_maybe_type of (Token.t (* "?" *) * primary_type)
-  | `Type_query of (
-        Token.t (* "typeof" *)
-      * [
-            `Type_query_subs_exp of type_query_subscript_expression
-          | `Type_query_member_exp of type_query_member_expression
-          | `Type_query_call_exp of type_query_call_expression
-          | `Type_query_inst_exp of type_query_instantiation_expression
-          | `Id of identifier (*tok*)
-          | `This of Token.t (* "this" *)
-        ]
-    )
-  | `Index_type_query of (Token.t (* "keyof" *) * primary_type)
-  | `This of Token.t (* "this" *)
-  | `Exis_type of Token.t (* "*" *)
-  | `Lit_type of literal_type
-  | `Lookup_type of (
-        primary_type * Token.t (* "[" *) * type_ * Token.t (* "]" *)
-    )
-  | `Cond_type of (
-        type_ * Token.t (* "extends" *) * type_ * Token.t (* "?" *) * type_
-      * Token.t (* ":" *) * type_
-    )
-  | `Temp_lit_type of (
-        Token.t (* "`" *)
-      * [
-            `Temp_chars of template_chars (*tok*)
-          | `Temp_type of template_type
-        ]
-          list (* zero or more *)
-      * Token.t (* "`" *)
-    )
-  | `Inte_type of (type_ option * Token.t (* "&" *) * type_)
-  | `Union_type of (type_ option * Token.t (* "|" *) * type_)
-  | `Const of Token.t (* "const" *)
+    `Choice_paren_type of [
+        `Paren_type of parenthesized_type
+      | `Pred_type of predefined_type
+      | `Id of identifier (*tok*)
+      | `Nested_type_id of nested_type_identifier
+      | `Gene_type of generic_type
+      | `Obj_type of object_type
+      | `Array_type of array_type
+      | `Tuple_type of tuple_type
+      | `Flow_maybe_type of flow_maybe_type
+      | `Type_query of type_query
+      | `Index_type_query of index_type_query
+      | `This of Token.t (* "this" *)
+      | `Exis_type of Token.t (* "*" *)
+      | `Lit_type of literal_type
+      | `Lookup_type of lookup_type
+      | `Cond_type of conditional_type
+      | `Temp_lit_type of template_literal_type
+      | `Inte_type of intersection_type
+      | `Union_type of union_type
+      | `Const of Token.t (* "const" *)
+    ]
+  | `Semg_ellips of Token.t (* "..." *)
+  | `Semg_meta of semgrep_metavariable (*tok*)
+  | `Semg_meta_ellips of semgrep_metavar_ellipsis (*tok*)
 ]
 
 and property_name = [
@@ -1491,6 +1493,13 @@ and switch_statement = (
     Token.t (* "switch" *) * parenthesized_expression * switch_body
 )
 
+and template_literal_type = (
+    Token.t (* "`" *)
+  * [ `Temp_chars of template_chars (*tok*) | `Temp_type of template_type ]
+      list (* zero or more *)
+  * Token.t (* "`" *)
+)
+
 and template_string = (
     Token.t (* "`" *)
   * [
@@ -1519,6 +1528,17 @@ and try_statement = (
   * statement_block
   * catch_clause option
   * finally_clause option
+)
+
+and tuple_type = (
+    Token.t (* "[" *)
+  * (
+        tuple_type_member
+      * (Token.t (* "," *) * tuple_type_member) list (* zero or more *)
+    )
+      option
+  * Token.t (* "," *) option
+  * Token.t (* "]" *)
 )
 
 and tuple_type_member = [
@@ -1572,17 +1592,11 @@ and type_arguments = (
   * Token.t (* ">" *)
 )
 
-and type_parameter = (
-    Token.t (* "const" *) option
-  * identifier (*tok*)
-  * constraint_ option
-  * default_type option
-)
-
 and type_parameters = (
     Token.t (* "<" *)
-  * type_parameter
-  * (Token.t (* "," *) * type_parameter) list (* zero or more *)
+  * anon_choice_type_param_61809f5
+  * (Token.t (* "," *) * anon_choice_type_param_61809f5)
+      list (* zero or more *)
   * Token.t (* "," *) option
   * Token.t (* ">" *)
 )
@@ -1598,6 +1612,18 @@ and type_predicate = (
 )
 
 and type_predicate_annotation = (Token.t (* ":" *) * type_predicate)
+
+and type_query = (
+    Token.t (* "typeof" *)
+  * [
+        `Type_query_subs_exp of type_query_subscript_expression
+      | `Type_query_member_exp of type_query_member_expression
+      | `Type_query_call_exp of type_query_call_expression
+      | `Type_query_inst_exp of type_query_instantiation_expression
+      | `Id of identifier (*tok*)
+      | `This of Token.t (* "this" *)
+    ]
+)
 
 and type_query_call_expression = (anon_choice_import_c99ceb4 * arguments)
 
@@ -1643,6 +1669,8 @@ and type_query_subscript_expression = (
     ]
   * Token.t (* "]" *)
 )
+
+and union_type = (type_ option * Token.t (* "|" *) * type_)
 
 and update_expression = [
     `Exp_choice_PLUSPLUS of (expression * anon_choice_PLUSPLUS_e498e28)
@@ -1735,7 +1763,10 @@ type semgrep_pattern = [
       * call_signature_
       * statement_block
     )
-  | `Obj_pat of object_pattern
+  | `Deco of decorator
+  | `Stmt of statement
+  | `Type of type_
+  | `Type_pred of type_predicate
 ]
 
 type anon_opt_choice_jsx_attr_name_rep_jsx_attr__8497dc0 =
@@ -1877,10 +1908,6 @@ type array_pattern (* inlined *) = (
   * Token.t (* "]" *)
 )
 
-type array_type (* inlined *) = (
-    primary_type * Token.t (* "[" *) * Token.t (* "]" *)
-)
-
 type as_expression (* inlined *) = (
     expression
   * Token.t (* "as" *)
@@ -1929,11 +1956,6 @@ type computed_property_name (* inlined *) = (
     Token.t (* "[" *) * expression * Token.t (* "]" *)
 )
 
-type conditional_type (* inlined *) = (
-    type_ * Token.t (* "extends" *) * type_ * Token.t (* "?" *) * type_
-  * Token.t (* ":" *) * type_
-)
-
 type construct_signature (* inlined *) = (
     Token.t (* "abstract" *) option
   * Token.t (* "new" *)
@@ -1964,8 +1986,6 @@ type enum_declaration (* inlined *) = (
   * enum_body
 )
 
-type flow_maybe_type (* inlined *) = (Token.t (* "?" *) * primary_type)
-
 type function_signature (* inlined *) = (
     Token.t (* "async" *) option
   * Token.t (* "function" *)
@@ -1985,8 +2005,6 @@ type function_type (* inlined *) = (
   * [ `Type of type_ | `Asserts of asserts | `Type_pred of type_predicate ]
 )
 
-type index_type_query (* inlined *) = (Token.t (* "keyof" *) * primary_type)
-
 type instantiation_expression (* inlined *) = (expression * type_arguments)
 
 type interface_declaration (* inlined *) = (
@@ -1995,16 +2013,6 @@ type interface_declaration (* inlined *) = (
   * type_parameters option
   * extends_type_clause option
   * object_type
-)
-
-type intersection_type (* inlined *) = (
-    type_ option
-  * Token.t (* "&" *)
-  * type_
-)
-
-type lookup_type (* inlined *) = (
-    primary_type * Token.t (* "[" *) * type_ * Token.t (* "]" *)
 )
 
 type module_ (* inlined *) = (Token.t (* "module" *) * module__)
@@ -2016,6 +2024,17 @@ type object_assignment_pattern (* inlined *) = (
     ]
   * Token.t (* "=" *)
   * expression
+)
+
+type object_pattern (* inlined *) = (
+    Token.t (* "{" *)
+  * (
+        anon_choice_pair_pat_3ff9cbe option
+      * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option)
+          list (* zero or more *)
+    )
+      option
+  * Token.t (* "}" *)
 )
 
 type optional_parameter (* inlined *) = (
@@ -2030,10 +2049,6 @@ type optional_tuple_parameter (* inlined *) = (
 )
 
 type optional_type (* inlined *) = (type_ * Token.t (* "?" *))
-
-type parenthesized_type (* inlined *) = (
-    Token.t (* "(" *) * type_ * Token.t (* ")" *)
-)
 
 type property_signature (* inlined *) = (
     accessibility_modifier option
@@ -2059,13 +2074,6 @@ type satisfies_expression (* inlined *) = (
     expression * Token.t (* "satisfies" *) * type_
 )
 
-type template_literal_type (* inlined *) = (
-    Token.t (* "`" *)
-  * [ `Temp_chars of template_chars (*tok*) | `Temp_type of template_type ]
-      list (* zero or more *)
-  * Token.t (* "`" *)
-)
-
 type ternary_expression (* inlined *) = (
     expression * ternary_qmark (*tok*) * expression * Token.t (* ":" *)
   * expression
@@ -2074,17 +2082,6 @@ type ternary_expression (* inlined *) = (
 type tuple_parameter (* inlined *) = (
     [ `Id of identifier (*tok*) | `Rest_pat of rest_pattern ]
   * type_annotation
-)
-
-type tuple_type (* inlined *) = (
-    Token.t (* "[" *)
-  * (
-        tuple_type_member
-      * (Token.t (* "," *) * tuple_type_member) list (* zero or more *)
-    )
-      option
-  * Token.t (* "," *) option
-  * Token.t (* "]" *)
 )
 
 type type_alias_declaration (* inlined *) = (
@@ -2098,16 +2095,11 @@ type type_alias_declaration (* inlined *) = (
 
 type type_assertion (* inlined *) = (type_arguments * expression)
 
-type type_query (* inlined *) = (
-    Token.t (* "typeof" *)
-  * [
-        `Type_query_subs_exp of type_query_subscript_expression
-      | `Type_query_member_exp of type_query_member_expression
-      | `Type_query_call_exp of type_query_call_expression
-      | `Type_query_inst_exp of type_query_instantiation_expression
-      | `Id of identifier (*tok*)
-      | `This of Token.t (* "this" *)
-    ]
+type type_parameter (* inlined *) = (
+    Token.t (* "const" *) option
+  * identifier (*tok*)
+  * constraint_ option
+  * default_type option
 )
 
 type unary_expression (* inlined *) = (
@@ -2122,8 +2114,6 @@ type unary_expression (* inlined *) = (
     ]
   * expression
 )
-
-type union_type (* inlined *) = (type_ option * Token.t (* "|" *) * type_)
 
 type yield_expression (* inlined *) = (
     Token.t (* "yield" *)

--- a/lib/Parse.ml
+++ b/lib/Parse.ml
@@ -1246,6 +1246,7 @@ let children_regexps : (string * Run.exp option) list = [
           Alt [|
             Token (Name "property_name");
             Token (Name "enum_assignment");
+            Token (Name "semgrep_ellipsis");
           |];
           Repeat (
             Seq [
@@ -1253,6 +1254,7 @@ let children_regexps : (string * Run.exp option) list = [
               Alt [|
                 Token (Name "property_name");
                 Token (Name "enum_assignment");
+                Token (Name "semgrep_ellipsis");
               |];
             ];
           );
@@ -2349,6 +2351,7 @@ let children_regexps : (string * Run.exp option) list = [
             Token (Name "construct_signature");
             Token (Name "index_signature");
             Token (Name "method_signature");
+            Token (Name "semgrep_ellipsis");
           |];
           Repeat (
             Seq [
@@ -2366,6 +2369,7 @@ let children_regexps : (string * Run.exp option) list = [
                 Token (Name "construct_signature");
                 Token (Name "index_signature");
                 Token (Name "method_signature");
+                Token (Name "semgrep_ellipsis");
               |];
             ];
           );
@@ -2613,26 +2617,31 @@ let children_regexps : (string * Run.exp option) list = [
   "primary_type",
   Some (
     Alt [|
-      Token (Name "parenthesized_type");
-      Token (Name "predefined_type");
-      Token (Name "identifier");
-      Token (Name "nested_type_identifier");
-      Token (Name "generic_type");
-      Token (Name "object_type");
-      Token (Name "array_type");
-      Token (Name "tuple_type");
-      Token (Name "flow_maybe_type");
-      Token (Name "type_query");
-      Token (Name "index_type_query");
-      Token (Name "this");
-      Token (Name "existential_type");
-      Token (Name "literal_type");
-      Token (Name "lookup_type");
-      Token (Name "conditional_type");
-      Token (Name "template_literal_type");
-      Token (Name "intersection_type");
-      Token (Name "union_type");
-      Token (Literal "const");
+      Alt [|
+        Token (Name "parenthesized_type");
+        Token (Name "predefined_type");
+        Token (Name "identifier");
+        Token (Name "nested_type_identifier");
+        Token (Name "generic_type");
+        Token (Name "object_type");
+        Token (Name "array_type");
+        Token (Name "tuple_type");
+        Token (Name "flow_maybe_type");
+        Token (Name "type_query");
+        Token (Name "index_type_query");
+        Token (Name "this");
+        Token (Name "existential_type");
+        Token (Name "literal_type");
+        Token (Name "lookup_type");
+        Token (Name "conditional_type");
+        Token (Name "template_literal_type");
+        Token (Name "intersection_type");
+        Token (Name "union_type");
+        Token (Literal "const");
+      |];
+      Token (Name "semgrep_ellipsis");
+      Token (Name "semgrep_metavariable");
+      Token (Name "semgrep_metavar_ellipsis");
     |];
   );
   "property_name",
@@ -3190,11 +3199,17 @@ let children_regexps : (string * Run.exp option) list = [
   Some (
     Seq [
       Token (Literal "<");
-      Token (Name "type_parameter");
+      Alt [|
+        Token (Name "type_parameter");
+        Token (Name "semgrep_ellipsis");
+      |];
       Repeat (
         Seq [
           Token (Literal ",");
-          Token (Name "type_parameter");
+          Alt [|
+            Token (Name "type_parameter");
+            Token (Name "semgrep_ellipsis");
+          |];
         ];
       );
       Opt (
@@ -3523,7 +3538,10 @@ let children_regexps : (string * Run.exp option) list = [
       Token (Name "finally_clause");
       Token (Name "catch_clause");
       Token (Name "assign_lambda");
-      Token (Name "object_pattern");
+      Token (Name "decorator");
+      Token (Name "statement");
+      Token (Name "type");
+      Token (Name "type_predicate");
     |];
   );
   "semgrep_expression",
@@ -6537,6 +6555,10 @@ and trans_enum_body ((kind, body) : mt) : CST.enum_body =
                           `Enum_assign (
                             trans_enum_assignment (Run.matcher_token v)
                           )
+                      | Alt (2, v) ->
+                          `Semg_ellips (
+                            trans_semgrep_ellipsis (Run.matcher_token v)
+                          )
                       | _ -> assert false
                       )
                       ,
@@ -6554,6 +6576,10 @@ and trans_enum_body ((kind, body) : mt) : CST.enum_body =
                                 | Alt (1, v) ->
                                     `Enum_assign (
                                       trans_enum_assignment (Run.matcher_token v)
+                                    )
+                                | Alt (2, v) ->
+                                    `Semg_ellips (
+                                      trans_semgrep_ellipsis (Run.matcher_token v)
                                     )
                                 | _ -> assert false
                                 )
@@ -9375,6 +9401,10 @@ and trans_object_type ((kind, body) : mt) : CST.object_type =
                           `Meth_sign (
                             trans_method_signature (Run.matcher_token v)
                           )
+                      | Alt (6, v) ->
+                          `Semg_ellips (
+                            trans_semgrep_ellipsis (Run.matcher_token v)
+                          )
                       | _ -> assert false
                       )
                       ,
@@ -9429,6 +9459,10 @@ and trans_object_type ((kind, body) : mt) : CST.object_type =
                                 | Alt (5, v) ->
                                     `Meth_sign (
                                       trans_method_signature (Run.matcher_token v)
+                                    )
+                                | Alt (6, v) ->
+                                    `Semg_ellips (
+                                      trans_semgrep_ellipsis (Run.matcher_token v)
                                     )
                                 | _ -> assert false
                                 )
@@ -10111,84 +10145,102 @@ and trans_primary_type ((kind, body) : mt) : CST.primary_type =
   | Children v ->
       (match v with
       | Alt (0, v) ->
-          `Paren_type (
-            trans_parenthesized_type (Run.matcher_token v)
+          `Choice_paren_type (
+            (match v with
+            | Alt (0, v) ->
+                `Paren_type (
+                  trans_parenthesized_type (Run.matcher_token v)
+                )
+            | Alt (1, v) ->
+                `Pred_type (
+                  trans_predefined_type (Run.matcher_token v)
+                )
+            | Alt (2, v) ->
+                `Id (
+                  trans_identifier (Run.matcher_token v)
+                )
+            | Alt (3, v) ->
+                `Nested_type_id (
+                  trans_nested_type_identifier (Run.matcher_token v)
+                )
+            | Alt (4, v) ->
+                `Gene_type (
+                  trans_generic_type (Run.matcher_token v)
+                )
+            | Alt (5, v) ->
+                `Obj_type (
+                  trans_object_type (Run.matcher_token v)
+                )
+            | Alt (6, v) ->
+                `Array_type (
+                  trans_array_type (Run.matcher_token v)
+                )
+            | Alt (7, v) ->
+                `Tuple_type (
+                  trans_tuple_type (Run.matcher_token v)
+                )
+            | Alt (8, v) ->
+                `Flow_maybe_type (
+                  trans_flow_maybe_type (Run.matcher_token v)
+                )
+            | Alt (9, v) ->
+                `Type_query (
+                  trans_type_query (Run.matcher_token v)
+                )
+            | Alt (10, v) ->
+                `Index_type_query (
+                  trans_index_type_query (Run.matcher_token v)
+                )
+            | Alt (11, v) ->
+                `This (
+                  trans_this (Run.matcher_token v)
+                )
+            | Alt (12, v) ->
+                `Exis_type (
+                  trans_existential_type (Run.matcher_token v)
+                )
+            | Alt (13, v) ->
+                `Lit_type (
+                  trans_literal_type (Run.matcher_token v)
+                )
+            | Alt (14, v) ->
+                `Lookup_type (
+                  trans_lookup_type (Run.matcher_token v)
+                )
+            | Alt (15, v) ->
+                `Cond_type (
+                  trans_conditional_type (Run.matcher_token v)
+                )
+            | Alt (16, v) ->
+                `Temp_lit_type (
+                  trans_template_literal_type (Run.matcher_token v)
+                )
+            | Alt (17, v) ->
+                `Inte_type (
+                  trans_intersection_type (Run.matcher_token v)
+                )
+            | Alt (18, v) ->
+                `Union_type (
+                  trans_union_type (Run.matcher_token v)
+                )
+            | Alt (19, v) ->
+                `Const (
+                  Run.trans_token (Run.matcher_token v)
+                )
+            | _ -> assert false
+            )
           )
       | Alt (1, v) ->
-          `Pred_type (
-            trans_predefined_type (Run.matcher_token v)
+          `Semg_ellips (
+            trans_semgrep_ellipsis (Run.matcher_token v)
           )
       | Alt (2, v) ->
-          `Id (
-            trans_identifier (Run.matcher_token v)
+          `Semg_meta (
+            trans_semgrep_metavariable (Run.matcher_token v)
           )
       | Alt (3, v) ->
-          `Nested_type_id (
-            trans_nested_type_identifier (Run.matcher_token v)
-          )
-      | Alt (4, v) ->
-          `Gene_type (
-            trans_generic_type (Run.matcher_token v)
-          )
-      | Alt (5, v) ->
-          `Obj_type (
-            trans_object_type (Run.matcher_token v)
-          )
-      | Alt (6, v) ->
-          `Array_type (
-            trans_array_type (Run.matcher_token v)
-          )
-      | Alt (7, v) ->
-          `Tuple_type (
-            trans_tuple_type (Run.matcher_token v)
-          )
-      | Alt (8, v) ->
-          `Flow_maybe_type (
-            trans_flow_maybe_type (Run.matcher_token v)
-          )
-      | Alt (9, v) ->
-          `Type_query (
-            trans_type_query (Run.matcher_token v)
-          )
-      | Alt (10, v) ->
-          `Index_type_query (
-            trans_index_type_query (Run.matcher_token v)
-          )
-      | Alt (11, v) ->
-          `This (
-            trans_this (Run.matcher_token v)
-          )
-      | Alt (12, v) ->
-          `Exis_type (
-            trans_existential_type (Run.matcher_token v)
-          )
-      | Alt (13, v) ->
-          `Lit_type (
-            trans_literal_type (Run.matcher_token v)
-          )
-      | Alt (14, v) ->
-          `Lookup_type (
-            trans_lookup_type (Run.matcher_token v)
-          )
-      | Alt (15, v) ->
-          `Cond_type (
-            trans_conditional_type (Run.matcher_token v)
-          )
-      | Alt (16, v) ->
-          `Temp_lit_type (
-            trans_template_literal_type (Run.matcher_token v)
-          )
-      | Alt (17, v) ->
-          `Inte_type (
-            trans_intersection_type (Run.matcher_token v)
-          )
-      | Alt (18, v) ->
-          `Union_type (
-            trans_union_type (Run.matcher_token v)
-          )
-      | Alt (19, v) ->
-          `Const (
-            Run.trans_token (Run.matcher_token v)
+          `Semg_meta_ellips (
+            trans_semgrep_metavar_ellipsis (Run.matcher_token v)
           )
       | _ -> assert false
       )
@@ -11471,14 +11523,35 @@ and trans_type_parameters ((kind, body) : mt) : CST.type_parameters =
       | Seq [v0; v1; v2; v3; v4] ->
           (
             Run.trans_token (Run.matcher_token v0),
-            trans_type_parameter (Run.matcher_token v1),
+            (match v1 with
+            | Alt (0, v) ->
+                `Type_param (
+                  trans_type_parameter (Run.matcher_token v)
+                )
+            | Alt (1, v) ->
+                `Semg_ellips (
+                  trans_semgrep_ellipsis (Run.matcher_token v)
+                )
+            | _ -> assert false
+            )
+            ,
             Run.repeat
               (fun v ->
                 (match v with
                 | Seq [v0; v1] ->
                     (
                       Run.trans_token (Run.matcher_token v0),
-                      trans_type_parameter (Run.matcher_token v1)
+                      (match v1 with
+                      | Alt (0, v) ->
+                          `Type_param (
+                            trans_type_parameter (Run.matcher_token v)
+                          )
+                      | Alt (1, v) ->
+                          `Semg_ellips (
+                            trans_semgrep_ellipsis (Run.matcher_token v)
+                          )
+                      | _ -> assert false
+                      )
                     )
                 | _ -> assert false
                 )
@@ -12274,8 +12347,20 @@ let trans_semgrep_pattern ((kind, body) : mt) : CST.semgrep_pattern =
             trans_assign_lambda (Run.matcher_token v)
           )
       | Alt (7, v) ->
-          `Obj_pat (
-            trans_object_pattern (Run.matcher_token v)
+          `Deco (
+            trans_decorator (Run.matcher_token v)
+          )
+      | Alt (8, v) ->
+          `Stmt (
+            trans_statement (Run.matcher_token v)
+          )
+      | Alt (9, v) ->
+          `Type (
+            trans_type_ (Run.matcher_token v)
+          )
+      | Alt (10, v) ->
+          `Type_pred (
+            trans_type_predicate (Run.matcher_token v)
           )
       | _ -> assert false
       )


### PR DESCRIPTION
## Summary

Regenerated parser sources from the upstream grammar fix in semgrep/ocaml-tree-sitter-semgrep#588. The new parser admits decorator-only Semgrep patterns (LANG-477), bare types and type predicates plus `...`/metavariables in any type-position slot (LANG-489), `...` inside interface bodies and object-type literals (LANG-500), `...` inside enum bodies (LANG-502), and `<...>` in generic-parameter lists plus `...` as a mapped-type value (LANG-504).

Companion PRs:
- semgrep/ocaml-tree-sitter-semgrep#588 (grammar source)
- semgrep/semgrep-tsx#2 (sibling regeneration)

## Test plan

- [ ] Pull this submodule into semgrep and run `make test`.
- [ ] Spot-check Semgrep rules using `@$DEC`, `interface $I { ... }`, `type T = ...`, `enum $E { ... }`, and `function $F<...>(...) { ... }` patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)